### PR TITLE
Fixes for Prestahop 1.7

### DIFF
--- a/reviewscouk/reviewscouk.php
+++ b/reviewscouk/reviewscouk.php
@@ -224,7 +224,7 @@ class ReviewsCoUk extends Module
 	{
 		if (Configuration::get('REVIEWSCOUK_CONFIG_DISPLAY_PRODUCT_WIDGET') == '1')
 		{
-			$product_sku = $params['product']->id;
+			$product_sku = $params['product']['id'];
 			$store_id = Configuration::get('REVIEWSCOUK_CONFIG_STOREID');
 			$color = Configuration::get('REVIEWSCOUK_CONFIG_WIDGET_COLOR');
 			$writeButton = Configuration::get('REVIEWSCOUK_CONFIG_WRITE_REVIEW_BUTTON');

--- a/reviewscouk/views/templates/front/widget.tpl
+++ b/reviewscouk/views/templates/front/widget.tpl
@@ -4,4 +4,4 @@
 *  @copyright  2014 Reviews.co.uk
 *  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div class="reviewscouk-reviews-widget">{$data|unescape:"htmlall"}</div>
+<div class="reviewscouk-reviews-widget">{$data nofilter}</div>


### PR DESCRIPTION
- nofilter is added to widget output to avoid escaping HTML markup.
- product sku is pulled from product array by key instead of property.